### PR TITLE
ci: changed to $GITHUB_OUTPUT from set-output

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -24,7 +24,7 @@ jobs:
       run: mvn -B package --file pom.xml
     - name: Set SHORT_SHA
       id: vars
-      run: echo "::set-output name=SHORT_SHA::$(git rev-parse --short HEAD)"
+      run: echo "SHORT_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
     - name: Create a Release
       id: create_release
       uses: actions/create-release@v1


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/